### PR TITLE
Add footprint for plate-mounted switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+Fork of [c0z3n/cherrymx-eagle](https://github.com/c0z3n/cherrymx-eagle), includes footprints for plate-mount switches
 cherrymx-eagle
 ==============
+
 
 ![cherry MX eagle library](http://i.imgur.com/szJnP7x.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-Fork of [c0z3n/cherrymx-eagle](https://github.com/c0z3n/cherrymx-eagle), includes footprints for plate-mount switches
 cherrymx-eagle
 ==============
-
 
 ![cherry MX eagle library](http://i.imgur.com/szJnP7x.png)
 

--- a/cherrymx.lbr
+++ b/cherrymx.lbr
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.1.0">
+<eagle version="9.0.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
+<setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -97,6 +98,16 @@
 <pad name="D1" x="-3.81" y="-5.08" drill="1.016" diameter="1.6764"/>
 <pad name="D2" x="3.81" y="-5.08" drill="1.016" diameter="1.6764"/>
 </package>
+<package name="CHERRY-MX-PM">
+<description>Cherry MX Keyswitch footprint (Plate mount)</description>
+<wire x1="-7.62" y1="7.62" x2="7.62" y2="7.62" width="0.127" layer="21"/>
+<wire x1="7.62" y1="7.62" x2="7.62" y2="-7.62" width="0.127" layer="21"/>
+<wire x1="7.62" y1="-7.62" x2="-7.62" y2="-7.62" width="0.127" layer="21"/>
+<wire x1="-7.62" y1="-7.62" x2="-7.62" y2="7.62" width="0.127" layer="21"/>
+<pad name="SW1" x="-3.81" y="2.54" drill="1.5" diameter="2.54"/>
+<pad name="SW2" x="2.54" y="5.08" drill="1.5" diameter="2.54"/>
+<hole x="0" y="0" drill="4.0004"/>
+</package>
 </packages>
 <symbols>
 <symbol name="CHERRY-MX">
@@ -145,6 +156,15 @@
 </gates>
 <devices>
 <device name="" package="CHERRY-MX">
+<connects>
+<connect gate="G$1" pin="PIN-1" pad="SW1"/>
+<connect gate="G$1" pin="PIN-2" pad="SW2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="PM" package="CHERRY-MX-PM">
 <connects>
 <connect gate="G$1" pin="PIN-1" pad="SW1"/>
 <connect gate="G$1" pin="PIN-2" pad="SW2"/>


### PR DESCRIPTION
Not having the mounting holes allows for some extra routing space. Tested with Hako True switches on a real PCB -- https://github.com/hristost/merp-pcb